### PR TITLE
[HOTFIX] - Mapper exit early when package not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/lsif-typescript",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "LSIF indexer for TypeScript and JavaScript",
   "publisher": "sourcefield",
   "bin": "dist/src/main.js",


### PR DESCRIPTION
Mapper was exiting early when references would not resolved due to requires not within a package

Fixes [bug](https://github.com/sourcefield-testing/syncthing/actions/runs/3323748991/jobs/5494494993#step:6:123)