### PR TITLE
Implement --skip arg to shortcut when needed in GitHub Workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Navigate to the project root, containing `package.json`.
 
 ```sh
 yarn build
+yarn unlink || true
 yarn link
 
 lsif-typescript index --yarn-workspaces # For Yarn v2

--- a/src/CommandLineOptions.test.ts
+++ b/src/CommandLineOptions.test.ts
@@ -1,37 +1,37 @@
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
 
-import { mainCommand, MultiProjectOptions } from './CommandLineOptions'
+import { mainCommand, MultiProjectOptions } from './CommandLineOptions';
 
 function checkIndexParser(
-  args: string[],
-  expectedOptions: Partial<MultiProjectOptions>,
-  expectedProjects?: string[]
+    args: string[],
+    expectedOptions: Partial<MultiProjectOptions>,
+    expectedProjects?: string[]
 ): void {
-  test(args.join(' '), () => {
-    let isAssertionTriggered = false
-    const actualArguments = ['node', 'scip-typescript.js', 'index', ...args]
-    mainCommand((projects, options) => {
-      assert.equal(options, { ...options, ...expectedOptions })
-      if (expectedProjects) {
-        assert.equal(projects, expectedProjects)
-      }
-      isAssertionTriggered = true
-    }).parse(actualArguments)
-    assert.ok(isAssertionTriggered)
-  })
+    test(args.join(' '), () => {
+        let isAssertionTriggered = false;
+        const actualArguments = ['node', 'scip-typescript.js', 'index', ...args];
+        mainCommand((projects, options) => {
+            assert.equal(options, { ...options, ...expectedOptions });
+            if (expectedProjects) {
+                assert.equal(projects, expectedProjects);
+            }
+            isAssertionTriggered = true;
+        }).parse(actualArguments);
+        assert.ok(isAssertionTriggered);
+    });
 }
 
 // defaults
 checkIndexParser([], {
-  progressBar: true,
-  cwd: process.cwd(),
-  inferTsconfig: false,
-  output: 'index.scip',
-  yarnWorkspaces: false,
-})
+    progressBar: true,
+    cwd: process.cwd(),
+    inferTsconfig: false,
+    output: 'index.yaml',
+    yarnWorkspaces: false,
+});
 
-checkIndexParser(['--cwd', 'qux'], { cwd: 'qux' })
-checkIndexParser(['--yarn-workspaces'], { yarnWorkspaces: true })
-checkIndexParser(['--infer-tsconfig'], { inferTsconfig: true })
-checkIndexParser(['--no-progress-bar'], { progressBar: false })
+checkIndexParser(['--cwd', 'qux'], { cwd: 'qux' });
+checkIndexParser(['--yarn-workspaces'], { yarnWorkspaces: true });
+checkIndexParser(['--infer-tsconfig'], { inferTsconfig: true });
+checkIndexParser(['--no-progress-bar'], { progressBar: false });

--- a/src/CommandLineOptions.ts
+++ b/src/CommandLineOptions.ts
@@ -15,6 +15,7 @@ export interface MultiProjectOptions {
     indexedProjects: Set<string>;
     explicitTsConfigJson: string;
     explicitImplicitLoop: boolean;
+    skip: string;
     dev: boolean;
 }
 
@@ -41,13 +42,18 @@ export function mainCommand(indexAction: (projects: string[], options: MultiProj
         .option('--yarn-workspaces', 'whether to index all yarn workspaces', false)
         .option('--yarn-berry-workspaces', 'whether to index all yarn v3 workspaces', false)
         .option('--infer-tsconfig', "whether to infer the tsconfig.json file, if it's missing", false)
-        .option('--output <path>', 'path to the output file', 'index.scip')
+        .option('--output <path>', 'path to the output file', 'index.yaml')
         .option('--no-progress-bar', 'whether to disable the progress bar')
         .option('--explicit-ts-config-json <filename>', 'Explicit tsconfig.json filename', 'tsconfig.json')
         .option(
             '--explicit-implicit-loop',
             'Loops over all tsconfig.*.json files && implicit tsconfig.json file => single map',
             false
+        )
+        .option(
+            '--skip <skip>',
+            'whether to skip the parse and emit an empty file or not; if "true", it will skip (all other values are ignored)',
+            'false'
         )
         .option('--dev', 'whether to run in dev mode - shows detailed print outputs')
         .argument('[projects...]')

--- a/src/FileIndexer.Components.test.ts
+++ b/src/FileIndexer.Components.test.ts
@@ -32,6 +32,7 @@ let options: ProjectOptions = {
     counter,
     explicitTsConfigJson: 'tsconfig.json',
     explicitImplicitLoop: false,
+    skip: 'false',
     dev: false,
 };
 

--- a/src/FileIndexer.Halstead.test.ts
+++ b/src/FileIndexer.Halstead.test.ts
@@ -32,6 +32,7 @@ let options: ProjectOptions = {
     counter,
     explicitTsConfigJson: 'tsconfig.json',
     explicitImplicitLoop: false,
+    skip: 'false',
     dev: false,
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,21 @@ export function indexCommand(projects: string[], options: MultiProjectOptions): 
         client.identify({ distinctId: actor });
     }
 
+    options.cwd = makeAbsolutePath(process.cwd(), options.cwd);
+    options.output = makeAbsolutePath(options.cwd, options.output);
+    if (!options.indexedProjects) {
+        options.indexedProjects = new Set();
+    }
+    const output = fs.openSync(options.output, 'w');
+
+    console.log('options.skip', options.skip);
+    if (options.skip === 'true') {
+        console.log('SKIPPING BECAUSE TRUE');
+        fs.writeSync(output, '{}\n');
+        fs.close(output);
+        return;
+    }
+
     installPackages(options.cwd);
 
     const start = new Date().getTime();
@@ -62,12 +77,6 @@ export function indexCommand(projects: string[], options: MultiProjectOptions): 
     } else if (projects.length === 0) {
         projects.push(options.cwd);
     }
-    options.cwd = makeAbsolutePath(process.cwd(), options.cwd);
-    options.output = makeAbsolutePath(options.cwd, options.output);
-    if (!options.indexedProjects) {
-        options.indexedProjects = new Set();
-    }
-    const output = fs.openSync(options.output, 'w');
     let documentCount = 0;
     let counter = new Counter();
     const writeIndex = (index: any): void => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,9 +58,7 @@ export function indexCommand(projects: string[], options: MultiProjectOptions): 
     }
     const output = fs.openSync(options.output, 'w');
 
-    console.log('options.skip', options.skip);
     if (options.skip === 'true') {
-        console.log('SKIPPING BECAUSE TRUE');
         fs.writeSync(output, '{}\n');
         fs.close(output);
         return;


### PR DESCRIPTION
Added `--skip <skip>` to accommodate `--skip true`, where it will skip a given step.  Also updated the docs on how to get thing running based upon `yarn unlink` and `yarn link` successive actions.